### PR TITLE
feat: enable Kaniko layer caching

### DIFF
--- a/.woodpecker.yaml
+++ b/.woodpecker.yaml
@@ -12,6 +12,8 @@ steps:
       dockerfile: MatrixClient/Dockerfile
       insecure: true
       insecure-pull: true
+      cache: true
+      cache-repo: registry-http.registry.svc.cluster.local/cache/matrixclient
     backend_options:
       kubernetes:
         nodeSelector:


### PR DESCRIPTION
Adds cache: true and cache-repo to the Kaniko build step. Caches layers to the local registry under registry-http.registry.svc.cluster.local/cache/LedMatrix2.